### PR TITLE
Remove bcrypt requirement

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'apinf:restivus-swagger',
-  version: '0.3.1',
+  version: '0.3.2',
   summary: 'Generate Swagger doc for API',
   git: 'https://github.com/apinf/restivus-swagger',
   documentation: 'README.md'
@@ -12,7 +12,6 @@ Npm.depends({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.2.1');
-  api.use('npm-bcrypt@=0.8.5', 'server');
   api.use(['ecmascript','underscore','nimble:restivus@0.8.7']);
   api.addFiles('server/restivus-swagger.js', ['server']);
 });


### PR DESCRIPTION
Bcrypt has no impact on this package, this will close this issue:
https://github.com/apinf/restivus-swagger/issues/11

Bumped version to 0.3.2