### PR TITLE
Allowed paths including 'users'

### DIFF
--- a/server/restivus-swagger.js
+++ b/server/restivus-swagger.js
@@ -46,8 +46,7 @@ Restivus.prototype.addSwagger = function(swaggerPath) {
           if (route.path !== swaggerPath &&
             route.path !== 'login' &&
             route.path !== 'logout' &&
-            !route.options.hidden &&
-            !route.path.includes('users') )
+            !route.options.hidden  )
           {
             // Modify path parameter to swagger spec style
             // Replaces :param with {param}


### PR DESCRIPTION
Closes #22 

When swagger document is created, also paths containing 'users' are needed to be included in the generated document.